### PR TITLE
Alloyui.com - Tutorials - Scheduler (Fixed the example dates)

### DIFF
--- a/src/documents/tutorials/scheduler/index.html.md.eco
+++ b/src/documents/tutorials/scheduler/index.html.md.eco
@@ -175,8 +175,8 @@ YUI().use(
       },
       {
         content: "Weeklong",
-        endDate: new Date(2013, 3, 25),
-        startDate: new Date(2013, 3, 19)
+        endDate: new Date(2013, 3, 27),
+        startDate: new Date(2013, 3, 21)
       }
     ];
 


### PR DESCRIPTION
The dates in the events variables did not produce valid results in the example code.
I checked all of them and now the tutorial code will render properly if copy/pasted.
I also removed a stray comma that was messing up Aptana code formatting.
