### PR TITLE
AUI-1399 Create tutorial for ColorPicker

### DIFF
--- a/src/documents/tutorials/color-picker/index.html.md.eco
+++ b/src/documents/tutorials/color-picker/index.html.md.eco
@@ -1,0 +1,180 @@
+---
+layout: single-doc
+title: Color Picker
+type: module
+category: Tutorial
+tags: color-picker
+description: Create a dynamic color picker that allows users to select a specific color in many ways including a popover menu, inline values or a palette.
+api: http://alloyui.com/api/modules/aui-color-picker.html
+---
+
+#### Getting Started
+
+First load the seed and CSS files, if you haven't yet.
+
+```html
+<script src="<%= @getCdnSeed() %>"></script>
+<link href="<%= @getBootstrapCSS() %>" rel="stylesheet"></link>
+```
+
+Then initialize AlloyUI and load the Color Picker submodule you want. There are several options available, including `aui-color-palette`, `aui-color-picker-popover`, `aui-hsv-palette`, `aui-hsva-palette`, and `aui-hsva-palette-modal`. We will use the popover version here.
+
+``` javascript
+YUI().use(
+  'aui-color-picker-popover',
+  function(Y) {
+    // code goes here
+  }
+);
+```
+
+---
+
+#### Using Color Picker
+
+Create an element to trigger a Color Picker Popover.
+
+``` html
+<label>Color trigger</label>
+<input class="colorPickerPopover" type="text">
+```
+
+Now, create a new instance of the Color Picker Popover component, define your `trigger`, and render it.
+
+``` javascript
+YUI().use(
+  'aui-color-picker-popover',
+  function(Y) {
+    new Y.ColorPickerPopover(
+      {
+        trigger: '.colorPickerPopover'
+      }
+    ).render();
+  }
+);
+```
+
+---
+
+#### Configuring Color Picker
+
+There are some other options that you can pass to your Color Picker instance, such as the other submodules. These submodules are created a bit differently.
+
+To use the `aui-color-palette`, create an HTML element to house the Color Picker.
+
+``` html
+<div id="colorPalette"></div>
+```
+Load the correct submodule (`aui-color-palette` in this case), create a new instance of the Color Palette, and render it. This will give you a default palette with 10 options.
+
+``` javascript
+YUI().use(
+  'aui-color-palette',
+  function(Y) {
+    new Y.ColorPalette().render('#colorPalette');
+  }
+);
+```
+In a Color Palette, you are also able to specify the exact colors to display using the `items` parameter. For example, this Color Palette will display two options: black and white.
+
+``` javascript
+YUI().use(
+  'aui-color-palette',
+  function(Y) {
+    new Y.ColorPalette({
+      items: [ "#000000", "#FFFFFF" ]
+    }).render('#colorPalette');
+  }
+);
+```
+It is also possible to load the base of the Color Picker instead of the specific submodule.
+
+``` javascript
+YUI().use(
+  'aui-color-picker-base',
+  function(Y) {
+    new Y.ColorPalette({
+      items: [ "#000000", "#FFFFFF" ]
+    }).render('#colorPalette');
+  }
+);
+```
+To use the HSV or HSVA Palette, create an HTML element to house the Color Picker.
+
+``` html
+<div id="hsvPalette"></div>
+```
+``` html
+<div id="hsvaPalette"></div>
+```
+Load the base submodule (the specific one would also work), create a new instance of the HSV or HSVA Palette, and render it.
+
+``` javascript
+YUI().use(
+  'aui-color-picker-base',
+  function(Y) {
+    new Y.HSVPalette().render('#hsvPalette');
+  }
+);
+```
+``` javascript
+YUI().use(
+  'aui-color-picker-base',
+  function(Y) {
+    new Y.HSVAPalette().render('#hsvaPalette');
+  }
+);
+```
+For both of these, there are two additional options possible, `controls` and `selected`. `controls` can be used to hide or show a set of text boxes to specify the color in Hex, RGB or HSVA values; by default they are shown. `selected` is used to set the default color that is selected when the Color Picker is first created. These can be set as follows.
+
+``` javascript
+YUI().use(
+  'aui-color-picker-base',
+  function(Y) {
+    new Y.HSVPalette({
+      controls: false,
+      selected: '00FF00'
+    }).render('#hsvPalette');
+  }
+);
+```
+``` javascript
+YUI().use(
+  'aui-color-picker-base',
+  function(Y) {
+    new Y.HSVAPalette({
+      controls: false,
+      selected: '0000FF00'
+    }).render('#hsvaPalette');
+  }
+);
+```
+
+Implementing a HSVA Palette Modal is a very similar process. First, create an HTML element for the Color Picker.
+``` html
+<div id="hsvaPaletteModal"></div>
+```
+Then, create a new instance of the HSVA Palette Modal and render it.
+
+``` javascript
+YUI().use(
+  'aui-color-picker-base',
+  function(Y) {
+    new Y.HSVAPaletteModal().render('#hsvaPaletteModal');
+  }
+);
+```
+By default, the HSVA Palette Modal is really an HSV Palette, because there is no alpha channel (which sets transparency). However, it is possible to activate the alpha channel by using the `hsv` attribute.
+
+``` javascript
+YUI().use(
+  'aui-color-picker-base',
+  function(Y) {
+    new Y.HSVAPaletteModal({
+      hsv: {
+        alpha: true
+      }
+    }).render('#hsvaPaletteModal');
+  }
+);
+```


### PR DESCRIPTION
See: [AUI-1399](https://issues.liferay.com/browse/AUI-1399)
Note: the jira ticket is to create both a tutorial and examples for this
module. This commit only contains the tutorial part. At this point, all
the submodules except the popover menu work by using the base submodule --
the popover one has to use the specific popover submodule.
