### PR TITLE
AUI-1400 Create tutorial for Dropdown

### DIFF
--- a/src/documents/tutorials/dropdown/index.html.md.eco
+++ b/src/documents/tutorials/dropdown/index.html.md.eco
@@ -1,0 +1,133 @@
+---
+layout: single-doc
+title: Dropdown
+tags: dropdown
+type: module
+category: Tutorial
+description: Enables the creation of dropdown menus.
+api: http://alloyui.com/api/modules/aui-dropdown.html
+---
+
+#### Getting Started
+
+First load the seed and CSS files, if you haven't yet.
+
+```html
+<script src="<%= @getCdnSeed() %>"></script>
+<link href="<%= @getBootstrapCSS() %>" rel="stylesheet"></link>
+```
+
+Then initialize AlloyUI and load the Dropdown module.
+
+``` javascript
+YUI().use(
+  'aui-dropdown',
+  function(Y) {
+    // code goes here
+  }
+);
+```
+---
+
+#### Using Dropdown
+
+Create an HTML element to hold the Dropdown module. The outer `ul` element represents the entire navigaiton bar and the `#myDropdown` item is where our submenu will be created.
+
+``` html
+<ul>
+  <li id="myDropdown">
+    <a id="myTrigger" href="#">Dropdown</a>
+  </li>
+</ul>
+```
+Now create a new instance of Dropdown component by setting the `boundingBox` to the `li` element we just created. Also, we should set `trigger` to the link inside the `li` element so that the menu will expand when a user clicks on the link. Then, let's render it!
+
+``` javascript
+YUI().use(
+  'aui-dropdown',
+  function(Y) {
+    new Y.Dropdown(
+      {
+        boundingBox: '#myDropdown',
+        trigger: '#myTrigger'
+      }
+    ).render();
+  }
+);
+```
+We have created the container for a dropdown menu, but right now it is empty. We still need to use the `items` attribute to specify the options to appear in the menu.
+
+``` javascript
+YUI().use(
+  'aui-dropdown',
+  function(Y) {
+    new Y.Dropdown(
+      {
+        boundingBox: '#myDropdown',
+        trigger: '#myTrigger',
+        items: [
+          {
+            id: 'item_with_id',
+            content: 'Hello'
+          },
+          {
+            content: 'World'
+          }
+        ]
+      }
+    ).render();
+  }
+);
+```
+Note the option to include an `id` for each item.
+
+---
+
+#### Configuring Dropdown
+
+There are some other options that you can pass to your Dropdown instance: `hideOnEsc` and `hideOnClickOutSide`. Both of these attributes control how the Dropdown items are hidden. By default, the items are hidden if the user clicks outside of the Dropdown menu or presses the `esc` key. These functions can be disabled by setting the appropriate attribute to false.
+
+``` javascript
+YUI().use(
+  'aui-dropdown',
+  function(Y) {
+    new Y.Dropdown(
+      {
+        boundingBox: '#myDropdown',
+        trigger: '#myTrigger',
+        hideOnEsc: false,
+        items: [
+          {
+            content: 'Hello'
+          },
+          {
+            content: 'World'
+          }
+        ]
+      }
+    ).render();
+  }
+);
+```
+``` javascript
+YUI().use(
+  'aui-dropdown',
+  function(Y) {
+    new Y.Dropdown(
+      {
+        boundingBox: '#myDropdown',
+        trigger: '#myTrigger',
+        hideOnClickOutSide: false,
+        items: [
+          {
+            content: 'Hello'
+          },
+          {
+            content: 'World'
+          }
+        ]
+      }
+    ).render();
+  }
+);
+```


### PR DESCRIPTION
See: [AUI-1400](https://issues.liferay.com/browse/AUI-1400)
Note: the jira ticket is to create both a tutorial and examples for this
module. This commit only contains the tutorial part. The linked api does
not exist at this point, but it should be the correct location. There is a
way to make a dropdown menu without using the 'items' attribute (using a
nested ul element instead) that is included in the demo, but it relies
on particular classes, so is not included in this tutorial.
