### PR TITLE
AUI-3124 - Fixes google fonts http to https for 1.0.x

### DIFF
--- a/src/layouts/default.html.eco
+++ b/src/layouts/default.html.eco
@@ -29,7 +29,7 @@
   <link href="<%= @getAssetsUrl() %>/css/main.css" rel="stylesheet">
 
   <!-- Fonts -->
-  <link href="http://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,700" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,700" rel="stylesheet">
 
   <!-- JS -->
   <script src="<%= @getCdnSeed() %>"></script>


### PR DESCRIPTION
Hey @zenorocha,<br><br>Attached is the fix for [AUI-3124](http://issues.liferay.com/browse/AUI-3124).<br><br>Let me know if you have any questions.<br><br>Thanks!